### PR TITLE
Circular Queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,8 @@ add_library(FastBufferTree
     include/buffer_tree.h
     src/buffer_control_block.cpp
     include/buffer_control_block.h
+    src/circular_queue.cpp
+    include/circular_queue.h
     include/update.h)
 target_link_libraries(FastBufferTree PRIVATE GTest::gtest)
 # optimize unless debug
@@ -83,7 +85,7 @@ if (UNIX AND NOT APPLE)
   target_compile_options(FastBufferTree PRIVATE -DHAVE_FALLOCATE)
 endif ()
 set_target_properties(FastBufferTree PROPERTIES PUBLIC_HEADER 
-  "include/buffer_tree.h;include/buffer_control_block.h;include/update.h"
+  "include/buffer_tree.h;include/buffer_control_block.h;include/circular_queue.h;include/update.h"
 )
 
 add_executable(buffertree_tests

--- a/experiment/experiment.cpp
+++ b/experiment/experiment.cpp
@@ -56,6 +56,7 @@ void run_test(const int nodes, const int num_updates, const int buffer_size, con
   printf("insertions took %f seconds: average rate = %f\n", delta.count(), num_updates/delta.count());
   buf_tree->force_flush();
   shutdown = true;
+  buf_tree->bypass_wait(); // tell any waiting threads to reset
 
   delta = std::chrono::steady_clock::now() - start;
   printf("insert+force_flush took %f seconds: average rate = %f\n", delta.count(), num_updates/delta.count());

--- a/experiment/experiment.cpp
+++ b/experiment/experiment.cpp
@@ -17,7 +17,7 @@ void querier(BufferTree *buf_tree, int nodes) {
   printf("creating query thread for buffertree\n");
   data_ret_t data;
   while(true) {
-    bool valid = buf_tree->get_data(shutdown, data);
+    bool valid = buf_tree->get_data(data);
     if (valid) {
       Node key = data.first;
       std::vector<Node> updates = data.second;

--- a/experiment/experiment.cpp
+++ b/experiment/experiment.cpp
@@ -1,12 +1,36 @@
 #include <gtest/gtest.h>
 #include <math.h>
-#include <set>
+#include <thread>
 #include <chrono>
 #include "../include/buffer_tree.h"
 
 #define KB 1 << 10
 #define MB 1 << 20
 #define GB 1 << 30
+
+static bool shutdown = false;
+
+// queries the buffer tree and verifies that the data
+// returned makes sense
+// Should be run in a seperate thread
+void querier(BufferTree *buf_tree, int nodes) {
+  printf("creating query thread for buffertree\n");
+  data_ret_t data;
+  while(true) {
+    bool valid = buf_tree->get_data(shutdown, data);
+    if (valid) {
+      Node key = data.first;
+      std::vector<Node> updates = data.second;
+      // verify that the updates are all between the correct nodes
+      for (Node upd : updates) {
+        // printf("edge to %d\n", upd.first);
+        ASSERT_EQ(nodes - (key + 1), upd) << "key " << key;
+      }
+    }
+    else if(shutdown)
+      return;
+  }
+}
 
 // helper function to run a basic test of the buffer tree with
 // various parameters
@@ -17,8 +41,10 @@ void run_test(const int nodes, const int num_updates, const int buffer_size, con
   printf("Running Test: nodes=%i num_updates=%i buffer_size %i branch_factor %i\n",
          nodes, num_updates, buffer_size, branch_factor);
 
-  BufferTree *buf_tree = new BufferTree("./test_", buffer_size, branch_factor, nodes, true);
-  
+  BufferTree *buf_tree = new BufferTree("./test_", buffer_size, branch_factor, nodes, 1, true);
+  shutdown = false;
+  std::thread qworker(querier, buf_tree, nodes);
+
   auto start = std::chrono::steady_clock::now();
   for (int i = 0; i < num_updates; i++) {
     update_t upd;
@@ -29,37 +55,12 @@ void run_test(const int nodes, const int num_updates, const int buffer_size, con
   std::chrono::duration<double> delta = std::chrono::steady_clock::now() - start;
   printf("insertions took %f seconds: average rate = %f\n", delta.count(), num_updates/delta.count());
   buf_tree->force_flush();
+  shutdown = true;
 
-  std::set<Node> visited;
+  delta = std::chrono::steady_clock::now() - start;
+  printf("insert+force_flush took %f seconds: average rate = %f\n", delta.count(), num_updates/delta.count());
 
-  // calculate the tag index for node 0 based upon max_level and max_buffer_size
-  work_t task;
-  while (!buf_tree->work_queue.empty()) {
-    task = buf_tree->work_queue.front();
-    buf_tree->work_queue.pop();
-
-    if (visited.count(task.first) > 0) {
-      continue;
-    }
-    visited.insert(task.first);
-    
-    // do the query
-    data_ret_t ret = buf_tree->get_data(task);
-    Node key = ret.first;
-    std::vector<Node> updates = ret.second;
-    // how many updates to we expect to see to each node
-    int per_node = num_updates / nodes;
-
-    int count = 0;
-
-    for (Node upd : updates) {
-      // printf("edge to %d\n", upd.first);
-      ASSERT_EQ(nodes - (key + 1), upd) << "key " << key;
-      count++;
-    }
-    ASSERT_EQ(per_node, count) << "key " << key;
-  }
-  
+  qworker.join();
   delete buf_tree;
 }
 

--- a/include/buffer_control_block.h
+++ b/include/buffer_control_block.h
@@ -14,7 +14,6 @@
 
 typedef uint32_t buffer_id_t;
 typedef uint64_t File_Pointer;
-typedef std::pair<Node, buffer_id_t> work_t;
 
 /**
  * Buffer metadata class. Care should be taken to synchronize access to the
@@ -97,7 +96,6 @@ public:
 
   inline void reset() {storage_ptr = 0;}
   inline buffer_id_t get_id() {return id;}
-  inline work_t work_info() {return work_t(min_key, id);}
   inline File_Pointer size() {return storage_ptr;}
   inline File_Pointer offset() {return file_offset;}
   inline void add_child(buffer_id_t child) {

--- a/include/buffer_tree.h
+++ b/include/buffer_tree.h
@@ -112,11 +112,6 @@ public:
    */
   bool get_data(bool noBlock, data_ret_t &data);
 
-  // queue of work which needs to be done and the locks which control access to it
-  std::queue<work_t> work_queue;
-  std::mutex queue_lock;
-  std::condition_variable queue_cond;
-
   /**
    * Flushes the entire tree down to the leaves.
    * @return nothing.

--- a/include/buffer_tree.h
+++ b/include/buffer_tree.h
@@ -192,5 +192,12 @@ public:
   }
 };
 
+class KeyIncorrectError : public std::exception {
+public:
+  virtual const char * what() const throw() {
+    return "The key was not correct for the associated buffer";
+  }
+};
+
 
 #endif //FASTBUFFERTREE_BUFFER_TREE_H

--- a/include/buffer_tree.h
+++ b/include/buffer_tree.h
@@ -106,11 +106,10 @@ public:
 
   /*
    * Ask the buffer tree for data and sleep if necessary until it is available.
-   * @param no_block   if false then block the current thread until data is available.
    * @param data       this is where to the key and vector of updates associated with it
    * @return           true true if got valid data, false if unable to get data.
    */
-  bool get_data(bool no_block, data_ret_t &data);
+  bool get_data(data_ret_t &data);
 
   /**
    * Flushes the entire tree down to the leaves.

--- a/include/buffer_tree.h
+++ b/include/buffer_tree.h
@@ -106,11 +106,11 @@ public:
 
   /*
    * Ask the buffer tree for data and sleep if necessary until it is available.
-   * @param noBlock if false then block the current thread until data is available.
-   * @param data    this is where to the key and vector of updates associated with it
-   * @return        true true if got valid data, false if unable to get data.
+   * @param no_block   if false then block the current thread until data is available.
+   * @param data       this is where to the key and vector of updates associated with it
+   * @return           true true if got valid data, false if unable to get data.
    */
-  bool get_data(bool noBlock, data_ret_t &data);
+  bool get_data(bool no_block, data_ret_t &data);
 
   /**
    * Flushes the entire tree down to the leaves.
@@ -119,26 +119,14 @@ public:
   flush_ret_t force_flush();
 
   /*
-   * Flushes the buffer:
-   * 0. Checks if the root buffer is busy. If it is, wait until not busy.
-   *    Lock the root.
-   * 1. If the buffer is not stored in memory, read into memory.
-   * 2. If the root is a leaf buffer:
-   *      a. Collate and write_updates().
-   *      b. Unlock the root and RETURN.
-   * 2. Run heavy-hitters algorithm.
-   * 3. write_updates() to heavy hitters, leaving gaps in the buffer where
-   *    the elements were.
-   * 4. Find fixed pivots within buffer to split data on.
-   * 5. Locks children that need to be written to.
-   * 6. File-appends elements to children buffers. Updates storage pointers
-   *    of children. If any children have over M elements, add them to the
-   *    flush queue.
-   * 7. Resets storage pointer of root buffer to 0 and free the auxiliary
-   *    memory used to store the buffer.
-   * 8. Unlock children and root (in that order, please) and RETURN.
+   * Notifies all threads waiting on condition variables that 
+   * they should check their wait condition again
+   * Useful when switching from blocking to non-blocking calls
+   * to the circular queue
+   * For example: we use this when shutting down the graph_workers\
+   * @return   nothing
    */
-  flush_ret_t flush();
+  void bypass_wait();
 
   /*
    * Function to convert an update_t to a char array

--- a/include/circular_queue.h
+++ b/include/circular_queue.h
@@ -8,14 +8,14 @@
 struct queue_elm {
 	bool dirty;    // is this queue element yet to be processed by sketching (if so do not overwrite)
 	uint32_t size; // the size of this data element
-	char *data;    // the data element which goes in the queue
+	char *data;    // a pointer to the data
 };
 
 /*
  * A circular queue of data elements.
  * Used in the bufferTree to place leaf data which is ready to be processed.
- * Has a finite size and will block operations which would either empty or
- * fill up the queue until they can proceed
+ * Has a finite size and will block operations which do not have the data
+ * that they need (either empty or full for peek and push respectively)
  */
 
 class CircularQueue {
@@ -49,8 +49,8 @@ private:
 	int head;     // where to push (starts at 0, write pointer)
 	int tail;     // where to peek (starts at 0, read pointer)
 	
-	queue_elm *queue_array; // array of char * which holds all the data
-
+	queue_elm *queue_array; // array queue_elm metadata
+	char *data_array;
 	inline int incr(int p) {return (p + 1) % len;}
 	inline bool full()     {return queue_array[head].dirty;} // if the next data item is dirty then full
 	inline bool empty()    {return (head == tail && !full());}

--- a/include/circular_queue.h
+++ b/include/circular_queue.h
@@ -14,8 +14,8 @@ struct queue_elm {
 /*
  * A circular queue of data elements.
  * Used in the bufferTree to place leaf data which is ready to be processed.
- * Has a finite size and will block operations which do not have the data
- * that they need (either empty or full for peek and push respectively)
+ * Has a finite size and will block operations which do not have what they
+ * need need (either empty or full for peek and push respectively)
  */
 
 class CircularQueue {

--- a/include/circular_queue.h
+++ b/include/circular_queue.h
@@ -27,7 +27,7 @@ public:
 	void push(char *elm, int size);              
 	
 	// get data from the queue for processing
-	bool peek(bool noBlock, std::pair<int, queue_elm> &ret);
+	bool peek(std::pair<int, queue_elm> &ret);
 	
 	// mark the queue element i as ready to be overwritten.
 	// Call pop after processing the data from peek
@@ -38,6 +38,10 @@ public:
 
 	std::condition_variable cirq_empty;
 	std::mutex read_lock;
+
+	// should CircularQueue peeks wait until they can succeed(false)
+	// or return false on failure (true)
+	bool no_block;
 private:
 	int len;      // maximum number of data elements to be stored in the queue
 	int elm_size; // size of an individual element in bytes

--- a/include/circular_queue.h
+++ b/include/circular_queue.h
@@ -1,0 +1,54 @@
+#ifndef QUEUE_GUARD
+#define QUEUE_GUARD
+
+#include <condition_variable>
+#include <mutex>
+#include <utility>
+
+struct queue_elm {
+	bool dirty;    // is this queue element yet to be processed by sketching (if so do not overwrite)
+	uint32_t size; // the size of this data element
+	char *data;    // the data element which goes in the queue
+};
+
+/*
+ * A circular queue of data elements.
+ * Used in the bufferTree to place leaf data which is ready to be processed.
+ * Has a finite size and will block operations which would either empty or
+ * fill up the queue until they can proceed
+ */
+
+class CircularQueue {
+public:
+	CircularQueue(int num_elements, int size_of_elm);
+	~CircularQueue();
+
+	// add a data element to the queue
+	void push(char *elm, int size);              
+	
+	// get data from the queue for processing
+	bool peek(bool noBlock, std::pair<int, queue_elm> &ret);
+	
+	// mark the queue element i as ready to be overwritten.
+	// Call pop after processing the data from peek
+	void pop(int i);                             
+
+	std::condition_variable cirq_full;
+	std::mutex write_lock;
+
+	std::condition_variable cirq_empty;
+	std::mutex read_lock;
+private:
+	int len;      // maximum number of data elements to be stored in the queue
+	int elm_size; // size of an individual element in bytes
+
+	int head;     // where to push (starts at 0, write pointer)
+	int tail;     // where to peek (starts at 0, read pointer)
+	
+	queue_elm *queue_array; // array of char * which holds all the data
+
+	inline int incr(int p) {return (p + 1) % len;}
+	inline bool full()     {return queue_array[head].dirty;} // if the next data item is dirty then full
+	inline bool empty()    {return (head == tail && !full());}
+};
+#endif

--- a/include/circular_queue.h
+++ b/include/circular_queue.h
@@ -50,7 +50,7 @@ private:
 	int tail;     // where to peek (starts at 0, read pointer)
 	
 	queue_elm *queue_array; // array queue_elm metadata
-	char *data_array;
+	char *data_array;       // the actual data
 	inline int incr(int p) {return (p + 1) % len;}
 	inline bool full()     {return queue_array[head].dirty;} // if the next data item is dirty then full
 	inline bool empty()    {return (head == tail && !full());}

--- a/src/buffer_tree.cpp
+++ b/src/buffer_tree.cpp
@@ -247,7 +247,7 @@ flush_ret_t BufferTree::do_flush(char *data, uint32_t data_size, uint32_t begin,
 	while (data - data_start < data_size) {
 		Node key = load_key(data);
 		uint32_t child  = which_child(key, min_key, max_key, options);
-		if (child > B - 1 || ) {
+		if (child > B - 1) {
 			printf("ERROR: incorrect child %u abandoning insert key=%lu min=%lu max=%lu\n", child, key, min_key, max_key);
 			printf("first child = %u\n", buffers[begin]->get_id());
 			printf("data pointer = %lu data_start=%lu data_size=%u\n", (uint64_t) data, (uint64_t) data_start, data_size);

--- a/src/buffer_tree.cpp
+++ b/src/buffer_tree.cpp
@@ -54,7 +54,7 @@ nodes, int workers, bool reset=false) : dir(dir), M(size), B(b), N(nodes) {
 
 	// open the file which will be our backing store for the non-root nodes
 	// create it if it does not already exist
-	std::string file_name = dir + "buffer_tree_v0.1.data";
+	std::string file_name = dir + "buffer_tree_v0.2.data";
 	printf("opening file %s\n", file_name.c_str());
 	backing_store = open(file_name.c_str(), file_flags, S_IRUSR | S_IWUSR);
 	if (backing_store == -1) {
@@ -397,4 +397,9 @@ flush_ret_t BufferTree::force_flush() {
 			flush_control_block(bcb);
 		}
 	}
+}
+
+void BufferTree::bypass_wait() {
+	cq->cirq_full.notify_all();
+	cq->cirq_empty.notify_all();
 }

--- a/src/buffer_tree.cpp
+++ b/src/buffer_tree.cpp
@@ -302,7 +302,6 @@ flush_ret_t inline BufferTree::flush_root() {
 		flush_queue1.pop();
 		flush_control_block(to_flush);
 	}
-
 }
 
 flush_ret_t inline BufferTree::flush_control_block(BufferControlBlock *bcb) {

--- a/src/buffer_tree.cpp
+++ b/src/buffer_tree.cpp
@@ -24,7 +24,7 @@ int      BufferTree::backing_store;
  * We assume that node indices begin at 0 and increase to N-1
  */
 BufferTree::BufferTree(std::string dir, uint32_t size, uint32_t b, Node
-nodes, bool reset=false) : dir(dir), M(size), B(b), N(nodes) {
+nodes, int workers, bool reset=false) : dir(dir), M(size), B(b), N(nodes) {
 	page_size = sysconf(_SC_PAGE_SIZE); // works on POSIX systems (alternative is boost)
 	int file_flags = O_RDWR | O_CREAT; // direct memory O_DIRECT may or may not be good
 	if (reset) {
@@ -39,7 +39,7 @@ nodes, bool reset=false) : dir(dir), M(size), B(b), N(nodes) {
 	// malloc the memory for the flush buffers
 	flush_buffers = (char **) malloc(sizeof(char *) * B);
 	for (uint i = 0; i < B; i++) {
-		flush_buffers[i] = (char *) calloc(page_size, sizeof(char *));
+		flush_buffers[i] = (char *) calloc(page_size, sizeof(char));
 	}
 	
 	// setup static variables
@@ -63,6 +63,10 @@ nodes, bool reset=false) : dir(dir), M(size), B(b), N(nodes) {
 	}
 
 	setup_tree(); // setup the buffer tree
+
+	// create the circular queue in which we will place ripe fruit (full leaves)
+	// make space for full updates of size 2 times the number of workers
+	cq = new CircularQueue(2*workers, M);
 	
 	// will want to use mmap instead? - how much is in RAM after allocation (none?)
 	// can't use mmap instead might use it as well. (Still need to create the file to be a given size)
@@ -130,9 +134,9 @@ void BufferTree::setup_tree() {
 			}
 
 			BufferControlBlock *bcb = new BufferControlBlock(start + index, size + max_buffer_size*index, l);
-	 		bcb->min_key     = key;
-	 		key              += ceil(parent_keys/options);
-			bcb->max_key     = key - 1;
+	 		bcb->min_key            = key;
+	 		key                     += ceil(parent_keys/options);
+			bcb->max_key            = key - 1;
 			if (l != 1)
 				buffers[prev]->add_child(start + index);
 			
@@ -237,7 +241,7 @@ flush_ret_t BufferTree::do_flush(char *data, uint32_t data_size, uint32_t begin,
 	char *data_start = data;
 	char **flush_positions = (char **) malloc(sizeof(char *) * B); // TODO move malloc out of this function
 	for (uint i = 0; i < B; i++) {
-		flush_positions[i] = flush_buffers[i]; // TODO this casting is annoying (just convert everything to update_t type?)
+		flush_positions[i] = flush_buffers[i];
 	}
 
 	while (data - data_start < data_size) {
@@ -302,15 +306,6 @@ flush_ret_t inline BufferTree::flush_root() {
 }
 
 flush_ret_t inline BufferTree::flush_control_block(BufferControlBlock *bcb) {
-	if (bcb->min_key == bcb->max_key) { // this is a leaf node
-		// printf("adding key %i from buffer %i to work queue\n", bcb->min_key, bcb->get_id());
-		std::unique_lock<std::mutex> lk(queue_lock);
-		work_queue.push(bcb->work_info());
-		lk.unlock();
-		queue_cond.notify_one();
-		return;
-	}
-
 	//printf("flushing "); bcb->print();
 
 	char *data = (char *) malloc(max_buffer_size); // TODO malloc only once instead of per call
@@ -325,6 +320,16 @@ flush_ret_t inline BufferTree::flush_control_block(BufferControlBlock *bcb) {
 		data_to_read -= len;
 		offset += len;
 	}
+
+	if (bcb->min_key == bcb->max_key) { // this is a leaf node
+		// printf("adding key %i from buffer %i to circular queue\n", bcb->min_key, bcb->get_id());
+		cq->push(data, bcb->size()); // add data to the circular queue
+		
+		// reset the BufferControlBlock (we have emptied it of data)
+		bcb->reset();
+		return;
+	}
+
 	// printf("read %lu bytes\n", len);
 
 	do_flush(data, bcb->size(), bcb->first_child, bcb->min_key, bcb->max_key, bcb->children_num, flush_queue_wild);
@@ -339,45 +344,47 @@ flush_ret_t inline BufferTree::flush_control_block(BufferControlBlock *bcb) {
 	}
 }
 
-// load data from buffer memory location so long as the key matches
-// what we expect
-data_ret_t BufferTree::get_data(work_t task) {
-	data_ret_t data;
-	Node key = task.first;
+// ask the buffer tree for data
+// this function may sleep until data is available
+bool BufferTree::get_data(bool noBlock, data_ret_t &data) {
+	File_Pointer idx = 0;
+
+	// make a request to the circular buffer for data
+	std::pair<int, queue_elm> queue_data;
+	bool got_data = cq->peek(noBlock, queue_data);
+
+	if (!got_data)
+		return false; // we got no data so return empty
+
+	int i         = queue_data.first;
+	queue_elm elm = queue_data.second;
+	char *serial_data = elm.data;
+	uint32_t len      = elm.size;
+
+	data.second.clear(); // remove any old data from the vector
+	uint32_t vec_len  = len / serial_update_size;
+	data.second.reserve(vec_len); // reserve space for our updates
+
+	// assume the first key is correct so extract it
+	Node key = deserialize_update(serial_data).first;
 	data.first = key;
-	File_Pointer off = 0;
-	BufferControlBlock *bcb = buffers[task.second];
 
-	// printf("getting data from positon %u and for key %u\n", task.second, key);
-
-	char *serial_data = (char *) malloc(bcb->size());
-	int len = pread(backing_store, serial_data, bcb->size(), bcb->offset());
-	// printf("read %lu bytes\n", len);
-	if (len == -1) {
-		printf("ERROR get_data failed to read from buffer %i, %s\n", bcb->get_id(), strerror(errno));
-		return data;
-	}
-
-	while(off < (uint64_t)len) {
-		update_t upd = deserialize_update(serial_data + off);
-		// printf("got update: %u %u %i\n", upd.first.first, upd.first.second, upd.second);
+	while(idx < (uint64_t) len) {
+		update_t upd = deserialize_update(serial_data + idx);
+		// printf("got update: %lu %lu\n", upd.first, upd.second);
 		if (upd.first == 0 && upd.second == 0) {
-			break; // got a null entry so clear that out
+			break; // got a null entry so done
 		}
 
 		if (upd.first == key) {
-			// printf("query to node %d got edge to node %d\n", key, upd.first.second);
+			// printf("query to node %lu got edge to node %lu\n", key, upd.second);
 			data.second.push_back(upd.second);
 		}
-		off += serial_update_size;
+		idx += serial_update_size;
 	}
 
-	free(serial_data);
-
-	// reset the BufferControlBlock (we have emptied it of data)
-	bcb->reset();
-
-	return data;
+	cq->pop(i); // mark the cq entry as clean
+	return true;
 }
 
 flush_ret_t BufferTree::force_flush() {
@@ -388,15 +395,7 @@ flush_ret_t BufferTree::force_flush() {
 	
 	for (BufferControlBlock *bcb : buffers) {
 		if (bcb != nullptr) {
-			if (bcb->min_key == bcb->max_key) {
-				// printf("Flushing key %i from buffer %i to work queue\n", bcb->min_key, bcb->get_id());
-				std::unique_lock<std::mutex> lk(queue_lock);
-				work_queue.push(bcb->work_info());
-				lk.unlock();
-				queue_cond.notify_one();
-			} else {
-				flush_control_block(bcb);
-			}
+			flush_control_block(bcb);
 		}
 	}
 }

--- a/src/buffer_tree.cpp
+++ b/src/buffer_tree.cpp
@@ -353,12 +353,15 @@ bool BufferTree::get_data(data_ret_t &data) {
 	bool got_data = cq->peek(queue_data);
 
 	if (!got_data)
-		return false; // we got no data so return empty
+		return false; // we got no data so return not valid
 
 	int i         = queue_data.first;
 	queue_elm elm = queue_data.second;
 	char *serial_data = elm.data;
 	uint32_t len      = elm.size;
+
+	if (len == 0)
+		return false; // we got no data so return not valid
 
 	data.second.clear(); // remove any old data from the vector
 	uint32_t vec_len  = len / serial_update_size;

--- a/src/buffer_tree.cpp
+++ b/src/buffer_tree.cpp
@@ -320,7 +320,7 @@ flush_ret_t inline BufferTree::flush_control_block(BufferControlBlock *bcb) {
 		offset += len;
 	}
 
-	if (bcb->min_key == bcb->max_key) { // this is a leaf node
+	if (bcb->min_key == bcb->max_key && bcb->size() > 0) { // this is a leaf node
 		// printf("adding key %i from buffer %i to circular queue\n", bcb->min_key, bcb->get_id());
 		cq->push(data, bcb->size()); // add data to the circular queue
 		
@@ -365,7 +365,7 @@ bool BufferTree::get_data(data_ret_t &data) {
 	data.second.reserve(vec_len); // reserve space for our updates
 
 	// assume the first key is correct so extract it
-	Node key = deserialize_update(serial_data).first;
+	Node key = load_key(serial_data);
 	data.first = key;
 
 	while(idx < (uint64_t) len) {

--- a/src/buffer_tree.cpp
+++ b/src/buffer_tree.cpp
@@ -65,8 +65,8 @@ nodes, int workers, bool reset=false) : dir(dir), M(size), B(b), N(nodes) {
 	setup_tree(); // setup the buffer tree
 
 	// create the circular queue in which we will place ripe fruit (full leaves)
-	// make space for full updates of size 2 times the number of workers
-	cq = new CircularQueue(2*workers, M);
+	// make space for full 2 * workers full updates
+	cq = new CircularQueue(2*workers, 2*M);
 	
 	// will want to use mmap instead? - how much is in RAM after allocation (none?)
 	// can't use mmap instead might use it as well. (Still need to create the file to be a given size)

--- a/src/buffer_tree.cpp
+++ b/src/buffer_tree.cpp
@@ -345,12 +345,12 @@ flush_ret_t inline BufferTree::flush_control_block(BufferControlBlock *bcb) {
 
 // ask the buffer tree for data
 // this function may sleep until data is available
-bool BufferTree::get_data(bool noBlock, data_ret_t &data) {
+bool BufferTree::get_data(data_ret_t &data) {
 	File_Pointer idx = 0;
 
 	// make a request to the circular buffer for data
 	std::pair<int, queue_elm> queue_data;
-	bool got_data = cq->peek(noBlock, queue_data);
+	bool got_data = cq->peek(queue_data);
 
 	if (!got_data)
 		return false; // we got no data so return empty
@@ -400,6 +400,6 @@ flush_ret_t BufferTree::force_flush() {
 }
 
 void BufferTree::bypass_wait() {
-	cq->cirq_full.notify_all();
+	cq->no_block = true; // circular queue operations should no longer block
 	cq->cirq_empty.notify_all();
 }

--- a/src/circular_queue.cpp
+++ b/src/circular_queue.cpp
@@ -49,13 +49,10 @@ void CircularQueue::push(char *elm, int size) {
 	}
 }
 
-bool CircularQueue::peek(bool no_block, std::pair<int, queue_elm> &ret) {
+bool CircularQueue::peek(std::pair<int, queue_elm> &ret) {
 	do {
-		// here we automatically wake back up after half a second. This is to address
-		// the case where the querying thread is so fast that it has emptied the
-		// queue before we can tell it to run no_block
 		std::unique_lock<std::mutex> lk(read_lock);
-		cirq_empty.wait_for(lk, std::chrono::milliseconds(500), [this, no_block]{return (!empty() || no_block);});
+		cirq_empty.wait(lk, [this]{return (!empty() || no_block);});
 		if(!empty()) {
 			// printf("CQ: peek: got non-empty");
 			int temp = tail;

--- a/src/circular_queue.cpp
+++ b/src/circular_queue.cpp
@@ -1,0 +1,78 @@
+#include "../include/circular_queue.h"
+#include "../include/update.h"
+#include "../include/buffer_tree.h"
+
+#include <string.h>
+
+CircularQueue::CircularQueue(int num_elements, int size_of_elm): 
+  len(num_elements), elm_size(size_of_elm) {
+	head = 0;
+	tail = 0;
+
+	// malloc the memory for the circular queue
+	queue_array = (queue_elm *) malloc(sizeof(queue_elm) * len);
+	for (int i = 0; i < len; i++) {
+		queue_array[i].data  = (char *) malloc(elm_size * sizeof(char));
+		queue_array[i].dirty = false;
+		queue_array[i].size  = 0;
+	}
+
+	printf("CQ: created circular queue with %i elements each of size %i\n", len, elm_size);
+}
+
+CircularQueue::~CircularQueue() {
+	// free the queue
+	for (int i = 0; i < len; i++) {
+		free(queue_array[i].data);
+	}
+	free(queue_array);
+}
+
+void CircularQueue::push(char *elm, int size) {
+	std::unique_lock<std::mutex> lk(write_lock);
+	while(true) {
+		// printf("CQ: push: wait on not-full. full() = %s\n", (full())? "true" : "false");
+		cirq_full.wait(lk, [this]{return !full();});
+		if(!full()) {
+			// printf("CQ: push: got not-full");
+			memcpy(queue_array[head].data, elm, size);
+			queue_array[head].dirty = true;
+			queue_array[head].size = size;
+			head = incr(head);
+			lk.unlock();
+			// printf(" new head is %i\n", head);
+			cirq_empty.notify_one();
+			break;
+		}
+		lk.unlock();
+	}
+}
+
+bool CircularQueue::peek(bool noBlock, std::pair<int, queue_elm> &ret) {
+	do {
+		std::unique_lock<std::mutex> lk(read_lock);
+		// printf("CQ: peek: wait on not-empty\n");
+		cirq_empty.wait(lk, [this, noBlock]{return (!empty() || noBlock);});
+		if(!empty()) {
+			// printf("CQ: peek: got non-empty");
+			int temp = tail;
+			tail = incr(tail);
+			lk.unlock();
+			// printf(" new tail is %i\n", tail);
+			ret.first = temp;
+			ret.second = queue_array[temp];
+			return true;
+		}
+		lk.unlock();
+	}while(!noBlock);
+	// printf("CQ: peek: EXITING without data due to noBlock\n");
+	return false;
+}
+
+void CircularQueue::pop(int i) {
+	read_lock.lock();
+	queue_array[i].dirty = false; // this data has been processed and this slot may now be overwritten
+	cirq_full.notify_one();
+	read_lock.unlock();
+	// printf("CQ: pop: popped item %i\n", i);
+}

--- a/src/circular_queue.cpp
+++ b/src/circular_queue.cpp
@@ -12,8 +12,9 @@ CircularQueue::CircularQueue(int num_elements, int size_of_elm):
 
 	// malloc the memory for the circular queue
 	queue_array = (queue_elm *) malloc(sizeof(queue_elm) * len);
+	data_array = (char *) malloc(elm_size * len * sizeof(char));
 	for (int i = 0; i < len; i++) {
-		queue_array[i].data  = (char *) malloc(elm_size * sizeof(char));
+		queue_array[i].data  = data_array + (elm_size * i);
 		queue_array[i].dirty = false;
 		queue_array[i].size  = 0;
 	}

--- a/test/basic_test.cpp
+++ b/test/basic_test.cpp
@@ -53,6 +53,7 @@ void run_test(const int nodes, const int num_updates, const int buffer_size, con
   }
   buf_tree->force_flush();
   shutdown = true;
+  buf_tree->bypass_wait(); // tell any waiting threads to reset
 
   qworker.join();
   delete buf_tree;

--- a/test/basic_test.cpp
+++ b/test/basic_test.cpp
@@ -1,11 +1,35 @@
 #include <gtest/gtest.h>
 #include <math.h>
-#include <set>
+#include <thread>
 #include "../include/buffer_tree.h"
 
 #define KB 1 << 10
 #define MB 1 << 20
 #define GB 1 << 30
+
+static bool shutdown = false;
+
+// queries the buffer tree and verifies that the data
+// returned makes sense
+// Should be run in a seperate thread
+void querier(BufferTree *buf_tree, int nodes) {
+  printf("creating query thread for buffertree\n");
+  data_ret_t data;
+  while(true) {
+    bool valid = buf_tree->get_data(shutdown, data);
+    if (valid) {
+      Node key = data.first;
+      std::vector<Node> updates = data.second;
+      // verify that the updates are all between the correct nodes
+      for (Node upd : updates) {
+        // printf("edge to %d\n", upd.first);
+        ASSERT_EQ(nodes - (key + 1), upd) << "key " << key;
+      }
+    }
+    else if(shutdown)
+      return;
+  }
+}
 
 // helper function to run a basic test of the buffer tree with
 // various parameters
@@ -16,8 +40,11 @@ void run_test(const int nodes, const int num_updates, const int buffer_size, con
   printf("Running Test: nodes=%i num_updates=%i buffer_size %i branch_factor %i\n",
          nodes, num_updates, buffer_size, branch_factor);
 
-  BufferTree *buf_tree = new BufferTree("./test_", buffer_size, branch_factor, nodes, true);
+  BufferTree *buf_tree = new BufferTree("./test_", buffer_size, branch_factor, nodes, 1, true);
+  shutdown = false;
+  std::thread qworker(querier, buf_tree, nodes);
 
+  printf("inserting updates to buffer tree\n");
   for (int i = 0; i < num_updates; i++) {
     update_t upd;
     upd.first = i % nodes;
@@ -25,37 +52,9 @@ void run_test(const int nodes, const int num_updates, const int buffer_size, con
     buf_tree->insert(upd);
   }
   buf_tree->force_flush();
+  shutdown = true;
 
-  std::set<Node> visited;
-
-  // calculate the tag index for node 0 based upon max_level and max_buffer_size
-  work_t task;
-  while (!buf_tree->work_queue.empty()) {
-    task = buf_tree->work_queue.front();
-    buf_tree->work_queue.pop();
-
-    if (visited.count(task.first) > 0) {
-      continue;
-    }
-    visited.insert(task.first);
-    
-    // do the query
-    data_ret_t ret = buf_tree->get_data(task);
-    Node key = ret.first;
-    std::vector<Node> updates = ret.second;
-    // how many updates to we expect to see to each node
-    int per_node = num_updates / nodes;
-
-    int count = 0;
-
-    for (Node upd : updates) {
-      // printf("edge to %d\n", upd.first);
-      ASSERT_EQ(nodes - (key + 1), upd) << "key " << key;
-      count++;
-    }
-    ASSERT_EQ(per_node, count) << "key " << key;
-  }
-  
+  qworker.join();
   delete buf_tree;
 }
 

--- a/test/basic_test.cpp
+++ b/test/basic_test.cpp
@@ -16,7 +16,7 @@ void querier(BufferTree *buf_tree, int nodes) {
   printf("creating query thread for buffertree\n");
   data_ret_t data;
   while(true) {
-    bool valid = buf_tree->get_data(shutdown, data);
+    bool valid = buf_tree->get_data(data);
     if (valid) {
       Node key = data.first;
       std::vector<Node> updates = data.second;
@@ -53,7 +53,7 @@ void run_test(const int nodes, const int num_updates, const int buffer_size, con
   }
   buf_tree->force_flush();
   shutdown = true;
-  buf_tree->bypass_wait(); // tell any waiting threads to reset
+  buf_tree->bypass_wait(); // switch to non-blocking calls in an effort to exit
 
   qworker.join();
   delete buf_tree;


### PR DESCRIPTION
So this is a redesign of the way data exits the buffer tree. The idea is to place full leaves into a circular buffer which lives in RAM. Therefore, we can reduce the IO contention in the buffer tree.