### PR TITLE
Basement node

### DIFF
--- a/include/buffer_control_block.h
+++ b/include/buffer_control_block.h
@@ -95,6 +95,8 @@ public:
    */
   void flush();
 
+  inline bool is_leaf()  {return min_key == max_key;}
+
   inline void reset() {storage_ptr = 0;}
   inline buffer_id_t get_id() {return id;}
   inline work_t work_info() {return work_t(min_key, id);}

--- a/include/buffer_tree.h
+++ b/include/buffer_tree.h
@@ -185,6 +185,7 @@ public:
   static uint32_t max_buffer_size;
   static uint32_t buffer_size;
   static uint64_t backing_EOF;
+  static uint64_t leaf_size;
   /*
    * File descriptor of backing file for storage
    */

--- a/include/buffer_tree.h
+++ b/include/buffer_tree.h
@@ -56,6 +56,11 @@ private:
   // buffer which we use when reading in BufferControlBlocks
   char *read_buffer;
 
+  // buffer we use when we need to flush within a flush
+  // we only have one right now because this should only
+  // ever happen for children
+  char *backup_read_buffer;
+
   /*
    * root node and functions for handling it
    */
@@ -79,6 +84,14 @@ private:
    */
   flush_ret_t do_flush(char *data, uint32_t size, uint32_t begin, Node min_key, Node max_key, uint8_t options, std::queue<BufferControlBlock *> &fq);
 
+  /*
+   * If when flushing a buffer it is discovered that a leaf
+   * needs to be flushed, do so with this function.
+   * @param leaf   The leaf buffer to be flushed
+   * @return       nothing
+   */
+  flush_ret_t flush_leaf(BufferControlBlock *leaf);
+  
   // Circular queue in which we place leaves that fill up
   CircularQueue *cq;
 

--- a/include/buffer_tree.h
+++ b/include/buffer_tree.h
@@ -58,7 +58,7 @@ private:
 
   // buffer we use when we need to flush within a flush
   // we only have one right now because this should only
-  // ever happen for children
+  // ever happen for leaves
   char *backup_read_buffer;
 
   /*
@@ -91,7 +91,7 @@ private:
    * @return       nothing
    */
   flush_ret_t flush_leaf(BufferControlBlock *leaf);
-  
+
   // Circular queue in which we place leaves that fill up
   CircularQueue *cq;
 

--- a/src/buffer_control_block.cpp
+++ b/src/buffer_control_block.cpp
@@ -28,19 +28,26 @@ bool BufferControlBlock::busy() {
 }
 
 inline bool BufferControlBlock::needs_flush(uint32_t size_written) {
-	return storage_ptr >= BufferTree::buffer_size && 
-		storage_ptr - size_written < BufferTree::buffer_size;
+	if(is_leaf())
+		return storage_ptr >= BufferTree::leaf_size && 
+			storage_ptr - size_written < BufferTree::leaf_size;
+	else
+		return storage_ptr >= BufferTree::buffer_size && 
+			storage_ptr - size_written < BufferTree::buffer_size;
 }
-
 
 bool BufferControlBlock::write(char *data, uint32_t size) {
 	// printf("Writing to buffer %d data pointer = %p with size %i\n", id, data, size);
-	if (storage_ptr + size > BufferTree::max_buffer_size) {
-		printf("buffer %i error\n", id);
+	if (is_leaf() && storage_ptr + size > 2 * BufferTree::leaf_size) {
+		printf("buffer %i too full [leaf]\n", id);
 		throw BufferFullError(id);
 	}
-	uint32_t orig_size = size;
+	else if(storage_ptr + size > BufferTree::max_buffer_size) {
+		printf("buffer %i too full [internal node]\n", id);
+		throw BufferFullError(id);
+	}
 
+	uint32_t orig_size = size;
 	uint32_t len = pwrite(BufferTree::backing_store, data, size, file_offset + storage_ptr);
 	int w = 0;
 	while(len < size) {

--- a/src/buffer_tree.cpp
+++ b/src/buffer_tree.cpp
@@ -48,7 +48,7 @@ nodes, int workers, bool reset=false) : dir(dir), M(size), B(b), N(nodes) {
 	buffer_size     = M; // probably figure out a better solution than this
 	max_buffer_size = 2 * M;
 	backing_EOF     = 0;
-	leaf_size       = floor(24 * pow(log(N) / log(2), 3)); // size of leaf proportional to size of sketch
+	leaf_size       = floor(24 * pow(log2(N), 3)); // size of leaf proportional to size of sketch
 	leaf_size       = (leaf_size < page_size)? page_size : leaf_size; //enforce size of at least page_size
 
 	// malloc the memory for the root node

--- a/src/buffer_tree.cpp
+++ b/src/buffer_tree.cpp
@@ -49,7 +49,7 @@ nodes, int workers, bool reset=false) : dir(dir), M(size), B(b), N(nodes) {
 	max_buffer_size = 2 * M;
 	backing_EOF     = 0;
 	leaf_size       = floor(24 * pow(log(N) / log(2), 3)); // size of leaf proportional to size of sketch
-	leaf_size       = (leaf_size < page_size)? page_size : leaf_size; //enforce at least 2 * page_size big
+	leaf_size       = (leaf_size < page_size)? page_size : leaf_size; //enforce size of at least page_size
 
 	// malloc the memory for the root node
 	root_node = (char *) malloc(buffer_size);
@@ -170,7 +170,7 @@ void BufferTree::setup_tree() {
     #endif
     
     backing_EOF = size;
-    print_tree(buffers);
+    // print_tree(buffers);
 }
 
 // serialize an update to a data location (should only be used for root I think)
@@ -427,7 +427,7 @@ bool BufferTree::get_data(data_ret_t &data) {
 
 flush_ret_t BufferTree::force_flush() {
 	// printf("Force flush\n");
-	flush_root();       
+	flush_root();
 	// loop through each of the bufferControlBlocks and flush it
 	// looping from 0 on should force a top to bottom flush (if we do this right)
 	


### PR DESCRIPTION
Originally we were planning on introducing basement nodes but I realized it makes just as much sense (if not more) to just make the leaves smaller.

This is because with the introduction of the circular queue we have a nice way of handling the fact that many updates will go to the same node.

Additionally, as we have more and more nodes in the graph, the size of the sketch will approach (but likely not exceed) 1 MB. This means the case where we have to do many leaf flushes for one parent flush will be very unlikely.