### PR TITLE
Fix circular queue size

### DIFF
--- a/src/buffer_tree.cpp
+++ b/src/buffer_tree.cpp
@@ -73,7 +73,7 @@ nodes, int workers, bool reset=false) : dir(dir), M(size), B(b), N(nodes) {
 
 	// create the circular queue in which we will place ripe fruit (full leaves)
 	// make space for full 2 * workers full updates
-	cq = new CircularQueue(2*workers, 2*M);
+	cq = new CircularQueue(2*workers, 2*leaf_size);
 	
 	// will want to use mmap instead? - how much is in RAM after allocation (none?)
 	// can't use mmap instead might use it as well. (Still need to create the file to be a given size)


### PR DESCRIPTION
The circular queue elements are currently being set to be too large. They should be proportional to the size of the leaves.